### PR TITLE
Adjust legend ordering for provider stack chart

### DIFF
--- a/src/components/charts/ProviderStackArea.tsx
+++ b/src/components/charts/ProviderStackArea.tsx
@@ -1,5 +1,6 @@
 // src/components/charts/ProviderStackArea.tsx
 "use client";
+import type { ComponentProps } from "react";
 import {
   LineChart,
   Line,
@@ -9,6 +10,7 @@ import {
   Legend,
   ResponsiveContainer,
   CartesianGrid,
+  DefaultLegendContent,
   type LegendPayload,
 } from "recharts";
 import { buildProviderStack, type Period } from "@/lib/aggregate";
@@ -122,6 +124,10 @@ export default function ProviderStackArea({
   // Grand total across the rendered series
   const grandTotal = sumByKeys(stackRows as any[], stackProviders as string[]);
 
+  const legendRenderer = (
+    props: ComponentProps<typeof DefaultLegendContent>,
+  ) => <DefaultLegendContent {...props} payload={legendPayload} />;
+
   return (
     <div aria-label={ariaLabel} className="w-full">
       <ResponsiveContainer width="100%" height={height}>
@@ -159,7 +165,10 @@ export default function ProviderStackArea({
               itemStyle={{ color: chartTheme.tooltip.color }}
               formatter={(val: number) => fmtUsd(val)}
             />
-            <Legend wrapperStyle={{ color: chartTheme.tooltip.color }} payload={legendPayload} />
+            <Legend
+              wrapperStyle={{ color: chartTheme.tooltip.color }}
+              content={legendRenderer}
+            />
             {drawProviders.map((p) => {
               const color = colorMap.get(p)!;
               return (

--- a/src/components/charts/ProviderStackArea.tsx
+++ b/src/components/charts/ProviderStackArea.tsx
@@ -9,7 +9,9 @@ import {
   Legend,
   ResponsiveContainer,
   CartesianGrid,
+  DefaultLegendContent,
   type LegendProps,
+  type LegendPayload,
 } from "recharts";
 import { buildProviderStack, type Period } from "@/lib/aggregate";
 import { autoPeriod, fmtUsd } from "./utils";
@@ -108,13 +110,17 @@ export default function ProviderStackArea({
     }
   }
 
-  const legendPayload: LegendProps["payload"] = legendProviders.map((provider) => ({
+  const legendPayload: LegendPayload[] = legendProviders.map((provider) => ({
     value: provider,
     color: rgba(colorMap.get(provider)!, 0.95),
     type: "line",
     id: provider,
     dataKey: provider,
   }));
+
+  const renderLegend: LegendProps["content"] = (props) => (
+    <DefaultLegendContent {...props} payload={legendPayload} />
+  );
 
   // Negligible data threshold (adjust if you like)
   const MIN_RENDER_USD = 0.01;
@@ -156,7 +162,7 @@ export default function ProviderStackArea({
             itemStyle={{ color: chartTheme.tooltip.color }}
             formatter={(val: number) => fmtUsd(val)}
           />
-          <Legend wrapperStyle={{ color: chartTheme.tooltip.color }} payload={legendPayload} />
+          <Legend wrapperStyle={{ color: chartTheme.tooltip.color }} content={renderLegend} />
           {drawProviders.map((p) => {
             const color = colorMap.get(p)!;
             return (

--- a/src/components/charts/ProviderStackArea.tsx
+++ b/src/components/charts/ProviderStackArea.tsx
@@ -9,10 +9,7 @@ import {
   Legend,
   ResponsiveContainer,
   CartesianGrid,
-  DefaultLegendContent,
-  type LegendProps,
   type LegendPayload,
-  type DefaultLegendContentProps,
 } from "recharts";
 import { buildProviderStack, type Period } from "@/lib/aggregate";
 import { autoPeriod, fmtUsd } from "./utils";
@@ -94,10 +91,6 @@ export default function ProviderStackArea({
     ? [...stackProviders.filter((p) => p !== primaryProvider), primaryProvider]
     : [...stackProviders];
 
-  const legendProviders = drawProviders.includes("Other")
-    ? [...drawProviders.filter((p) => p !== "Other"), "Other"]
-    : drawProviders;
-
   // Color map: primary -> series[0], others -> series[3], [4], [7], [8]
   const remainingIdx = [3, 4, 7, 8];
   const colorMap = new Map<string, string>();
@@ -111,33 +104,17 @@ export default function ProviderStackArea({
     }
   }
 
+  const legendProviders = drawProviders.includes("Other")
+    ? [...drawProviders.filter((p) => p !== "Other"), "Other"]
+    : drawProviders;
+
   const legendPayload: LegendPayload[] = legendProviders.map((provider) => ({
     value: provider,
     color: rgba(colorMap.get(provider)!, 0.95),
-    type: "line",
+    type: "line" as const,
     id: provider,
     dataKey: provider,
   }));
-
-  const renderLegend: LegendProps["content"] = (props) => {
-    const defaultLegendProps: DefaultLegendContentProps = {
-      align: props.align,
-      verticalAlign: props.verticalAlign,
-      layout: props.layout,
-      iconSize: props.iconSize,
-      iconType: props.iconType,
-      formatter: props.formatter,
-      inactiveColor: props.inactiveColor,
-      className: props.className,
-      style: props.style,
-      onClick: props.onClick,
-      onMouseEnter: props.onMouseEnter,
-      onMouseLeave: props.onMouseLeave,
-      payload: legendPayload,
-    };
-
-    return <DefaultLegendContent {...defaultLegendProps} />;
-  };
 
   // Negligible data threshold (adjust if you like)
   const MIN_RENDER_USD = 0.01;
@@ -182,7 +159,7 @@ export default function ProviderStackArea({
               itemStyle={{ color: chartTheme.tooltip.color }}
               formatter={(val: number) => fmtUsd(val)}
             />
-            <Legend wrapperStyle={{ color: chartTheme.tooltip.color }} content={renderLegend} />
+            <Legend wrapperStyle={{ color: chartTheme.tooltip.color }} payload={legendPayload} />
             {drawProviders.map((p) => {
               const color = colorMap.get(p)!;
               return (

--- a/src/components/charts/ProviderStackArea.tsx
+++ b/src/components/charts/ProviderStackArea.tsx
@@ -12,6 +12,7 @@ import {
   DefaultLegendContent,
   type LegendProps,
   type LegendPayload,
+  type DefaultLegendContentProps,
 } from "recharts";
 import { buildProviderStack, type Period } from "@/lib/aggregate";
 import { autoPeriod, fmtUsd } from "./utils";
@@ -118,9 +119,25 @@ export default function ProviderStackArea({
     dataKey: provider,
   }));
 
-  const renderLegend: LegendProps["content"] = (props) => (
-    <DefaultLegendContent {...props} payload={legendPayload} />
-  );
+  const renderLegend: LegendProps["content"] = (props) => {
+    const defaultLegendProps: DefaultLegendContentProps = {
+      align: props.align,
+      verticalAlign: props.verticalAlign,
+      layout: props.layout,
+      iconSize: props.iconSize,
+      iconType: props.iconType,
+      formatter: props.formatter,
+      inactiveColor: props.inactiveColor,
+      className: props.className,
+      style: props.style,
+      onClick: props.onClick,
+      onMouseEnter: props.onMouseEnter,
+      onMouseLeave: props.onMouseLeave,
+      payload: legendPayload,
+    };
+
+    return <DefaultLegendContent {...defaultLegendProps} />;
+  };
 
   // Negligible data threshold (adjust if you like)
   const MIN_RENDER_USD = 0.01;
@@ -132,56 +149,59 @@ export default function ProviderStackArea({
     <div aria-label={ariaLabel} className="w-full">
       <ResponsiveContainer width="100%" height={height}>
         {hasMeaningful(grandTotal) ? (
-        <LineChart data={stackRows} margin={{ top: 8, right: 16, bottom: chartTheme.axis.fontSize * 1, left: 8 }}>
-          <CartesianGrid stroke={chartTheme.grid.stroke} />
-          <XAxis
-            dataKey="key"
-            axisLine={{ stroke: chartTheme.axis.line.stroke }}
-            tickLine={{ stroke: chartTheme.axis.line.stroke }}
-            tick={{ fill: chartTheme.axis.tick.fill, fontSize: chartTheme.axis.fontSize - 1 }}
-            tickMargin={8}
-            minTickGap={18}
-          />
-          <YAxis
-            axisLine={{ stroke: chartTheme.axis.line.stroke }}
-            tickLine={{ stroke: chartTheme.axis.line.stroke }}
-            tick={{ fill: chartTheme.axis.tick.fill, fontSize: chartTheme.axis.fontSize }}
-            stroke={chartTheme.axis.line.stroke}
-            tickFormatter={(v) => fmtUsd(v as number)}
-            width={60}
-          />
-          <Tooltip
-            cursor={chartTheme.hoverCursor}
-            contentStyle={{
-              background: chartTheme.tooltip.bg,
-              border: chartTheme.tooltip.border,
-              borderRadius: chartTheme.tooltip.radius,
-              color: chartTheme.tooltip.color,
-            }}
-            labelStyle={{ color: chartTheme.tooltip.color }}
-            itemStyle={{ color: chartTheme.tooltip.color }}
-            formatter={(val: number) => fmtUsd(val)}
-          />
-          <Legend wrapperStyle={{ color: chartTheme.tooltip.color }} content={renderLegend} />
-          {drawProviders.map((p) => {
-            const color = colorMap.get(p)!;
-            return (
-              <Line
-                key={p}
-                type="monotone"
-                dataKey={p}
-                stroke={rgba(color, 0.95)}
-                strokeWidth={3}
-                dot={false}
-                activeDot={{ r: 2.5, style: { filter: chartTheme.shadowCss.glowSm } }}
-                isAnimationActive={false}
-              />
-            );
-          })}
-        </LineChart>
+          <LineChart
+            data={stackRows}
+            margin={{ top: 8, right: 16, bottom: chartTheme.axis.fontSize * 1, left: 8 }}
+          >
+            <CartesianGrid stroke={chartTheme.grid.stroke} />
+            <XAxis
+              dataKey="key"
+              axisLine={{ stroke: chartTheme.axis.line.stroke }}
+              tickLine={{ stroke: chartTheme.axis.line.stroke }}
+              tick={{ fill: chartTheme.axis.tick.fill, fontSize: chartTheme.axis.fontSize - 1 }}
+              tickMargin={8}
+              minTickGap={18}
+            />
+            <YAxis
+              axisLine={{ stroke: chartTheme.axis.line.stroke }}
+              tickLine={{ stroke: chartTheme.axis.line.stroke }}
+              tick={{ fill: chartTheme.axis.tick.fill, fontSize: chartTheme.axis.fontSize }}
+              stroke={chartTheme.axis.line.stroke}
+              tickFormatter={(v) => fmtUsd(v as number)}
+              width={60}
+            />
+            <Tooltip
+              cursor={chartTheme.hoverCursor}
+              contentStyle={{
+                background: chartTheme.tooltip.bg,
+                border: chartTheme.tooltip.border,
+                borderRadius: chartTheme.tooltip.radius,
+                color: chartTheme.tooltip.color,
+              }}
+              labelStyle={{ color: chartTheme.tooltip.color }}
+              itemStyle={{ color: chartTheme.tooltip.color }}
+              formatter={(val: number) => fmtUsd(val)}
+            />
+            <Legend wrapperStyle={{ color: chartTheme.tooltip.color }} content={renderLegend} />
+            {drawProviders.map((p) => {
+              const color = colorMap.get(p)!;
+              return (
+                <Line
+                  key={p}
+                  type="monotone"
+                  dataKey={p}
+                  stroke={rgba(color, 0.95)}
+                  strokeWidth={3}
+                  dot={false}
+                  activeDot={{ r: 2.5, style: { filter: chartTheme.shadowCss.glowSm } }}
+                  isAnimationActive={false}
+                />
+              );
+            })}
+          </LineChart>
         ) : (
-        <ChartPlaceholder />
-      )}
+          <ChartPlaceholder />
+        )}
       </ResponsiveContainer>
     </div>
   );

--- a/src/components/charts/ProviderStackArea.tsx
+++ b/src/components/charts/ProviderStackArea.tsx
@@ -1,6 +1,5 @@
 // src/components/charts/ProviderStackArea.tsx
 "use client";
-import type { ComponentProps } from "react";
 import {
   LineChart,
   Line,
@@ -10,7 +9,6 @@ import {
   Legend,
   ResponsiveContainer,
   CartesianGrid,
-  DefaultLegendContent,
   type LegendPayload,
 } from "recharts";
 import { buildProviderStack, type Period } from "@/lib/aggregate";
@@ -110,23 +108,23 @@ export default function ProviderStackArea({
     ? [...drawProviders.filter((p) => p !== "Other"), "Other"]
     : drawProviders;
 
-  const legendPayload: LegendPayload[] = legendProviders.map((provider) => ({
-    value: provider,
-    color: rgba(colorMap.get(provider)!, 0.95),
-    type: "line" as const,
-    id: provider,
-    dataKey: provider,
-  }));
+  const legendOrder = new Map<string, number>();
+  legendProviders.forEach((provider, index) => {
+    legendOrder.set(provider, index);
+  });
+
+  const legendSorter = (entry: LegendPayload) => {
+    const key =
+      (typeof entry.value === "string" && entry.value) ||
+      (typeof entry.dataKey === "string" ? entry.dataKey : undefined);
+    return key !== undefined ? legendOrder.get(key) ?? legendProviders.length : legendProviders.length;
+  };
 
   // Negligible data threshold (adjust if you like)
   const MIN_RENDER_USD = 0.01;
 
   // Grand total across the rendered series
   const grandTotal = sumByKeys(stackRows as any[], stackProviders as string[]);
-
-  const legendRenderer = (
-    props: ComponentProps<typeof DefaultLegendContent>,
-  ) => <DefaultLegendContent {...props} payload={legendPayload} />;
 
   return (
     <div aria-label={ariaLabel} className="w-full">
@@ -167,7 +165,7 @@ export default function ProviderStackArea({
             />
             <Legend
               wrapperStyle={{ color: chartTheme.tooltip.color }}
-              content={legendRenderer}
+              itemSorter={legendSorter}
             />
             {drawProviders.map((p) => {
               const color = colorMap.get(p)!;

--- a/src/components/charts/ProviderStackArea.tsx
+++ b/src/components/charts/ProviderStackArea.tsx
@@ -1,6 +1,16 @@
 // src/components/charts/ProviderStackArea.tsx
 "use client";
-import { LineChart, Line, XAxis, YAxis, Tooltip, Legend, ResponsiveContainer, CartesianGrid } from "recharts";
+import {
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  Tooltip,
+  Legend,
+  ResponsiveContainer,
+  CartesianGrid,
+  type LegendProps,
+} from "recharts";
 import { buildProviderStack, type Period } from "@/lib/aggregate";
 import { autoPeriod, fmtUsd } from "./utils";
 import { chartTheme, rgba } from "./theme";
@@ -81,6 +91,10 @@ export default function ProviderStackArea({
     ? [...stackProviders.filter((p) => p !== primaryProvider), primaryProvider]
     : [...stackProviders];
 
+  const legendProviders = drawProviders.includes("Other")
+    ? [...drawProviders.filter((p) => p !== "Other"), "Other"]
+    : drawProviders;
+
   // Color map: primary -> series[0], others -> series[3], [4], [7], [8]
   const remainingIdx = [3, 4, 7, 8];
   const colorMap = new Map<string, string>();
@@ -93,6 +107,14 @@ export default function ProviderStackArea({
       idx++;
     }
   }
+
+  const legendPayload: LegendProps["payload"] = legendProviders.map((provider) => ({
+    value: provider,
+    color: rgba(colorMap.get(provider)!, 0.95),
+    type: "line",
+    id: provider,
+    dataKey: provider,
+  }));
 
   // Negligible data threshold (adjust if you like)
   const MIN_RENDER_USD = 0.01;
@@ -134,7 +156,7 @@ export default function ProviderStackArea({
             itemStyle={{ color: chartTheme.tooltip.color }}
             formatter={(val: number) => fmtUsd(val)}
           />
-          <Legend wrapperStyle={{ color: chartTheme.tooltip.color }} />
+          <Legend wrapperStyle={{ color: chartTheme.tooltip.color }} payload={legendPayload} />
           {drawProviders.map((p) => {
             const color = colorMap.get(p)!;
             return (


### PR DESCRIPTION
## Summary
- ensure the provider legend reorders the "Other" entry to render last
- add a custom legend payload that preserves existing draw ordering while reordering legend display

## Testing
- npm run lint *(fails: existing lint errors across unrelated files)*
- npm run test *(fails: vitest cannot resolve the "@/lib/io" import in src/lib/io.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68fe912ed0a4832c92190bd60defaa9d